### PR TITLE
Add unit tests for load_extern_type function in import_utils.py

### DIFF
--- a/.github/workflows/dataset.yml
+++ b/.github/workflows/dataset.yml
@@ -7,7 +7,7 @@ on:
     branches:
       - main
     paths:
-      - "verl/utils/dataset/*.py"
+      - "verl/utils/**/*.py"
       - .github/workflows/dataset.yml
       - "!verl/workers/fsdp_workers.py"
       - "!verl/workers/megatron_workers.py"
@@ -49,6 +49,7 @@ jobs:
           [ ! -d "$HOME/verl-data" ] && git clone --depth 1 https://github.com/eric-haibin-lin/verl-data ~/verl-data
           pytest -s -x tests/verl/utils/dataset/test_rl_dataset.py
           pytest -s -x tests/verl/utils/dataset/test_sft_dataset.py
+          pytest -s -x tests/verl/utils/test_import_utils.py
 #          pytest -s -x tests/verl/utils/dataset/test_rm_dataset.py
       - name: Running ray test using cupy (move it to L20 when dockerfile ready)
         run: |

--- a/tests/verl/utils/test_import_utils.py
+++ b/tests/verl/utils/test_import_utils.py
@@ -1,0 +1,113 @@
+# Copyright 2024 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import sys
+import importlib.util
+import pytest
+
+# Path to the test module
+TEST_MODULE_PATH = os.path.join(os.path.dirname(__file__), "test_module.py")
+
+
+# Import the load_extern_type function directly from the file
+def import_function_from_file(file_path, function_name):
+    """Import a function from a file without importing the entire module"""
+    spec = importlib.util.spec_from_file_location("module", file_path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return getattr(module, function_name)
+
+
+# Get the path to the import_utils.py file
+IMPORT_UTILS_PATH = os.path.join(os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(__file__)))), "verl",
+                                 "utils", "import_utils.py")
+
+# Import the load_extern_type function
+load_extern_type = import_function_from_file(IMPORT_UTILS_PATH, "load_extern_type")
+
+
+def test_load_extern_type_class():
+    """Test loading a class from an external file"""
+    TestClass = load_extern_type(TEST_MODULE_PATH, "TestClass")
+
+    # Verify the class was loaded correctly
+    assert TestClass is not None
+    assert TestClass.__name__ == "TestClass"
+
+    # Test instantiation and functionality
+    instance = TestClass()
+    assert instance.value == "default"
+
+    # Test with a custom value
+    custom_instance = TestClass("custom")
+    assert custom_instance.get_value() == "custom"
+
+
+def test_load_extern_type_function():
+    """Test loading a function from an external file"""
+    test_function = load_extern_type(TEST_MODULE_PATH, "test_function")
+
+    # Verify the function was loaded correctly
+    assert test_function is not None
+    assert callable(test_function)
+
+    # Test function execution
+    result = test_function()
+    assert result == "test_function_result"
+
+
+def test_load_extern_type_constant():
+    """Test loading a constant from an external file"""
+    constant = load_extern_type(TEST_MODULE_PATH, "TEST_CONSTANT")
+
+    # Verify the constant was loaded correctly
+    assert constant is not None
+    assert constant == "test_constant_value"
+
+
+def test_load_extern_type_nonexistent_file():
+    """Test behavior when file doesn't exist"""
+    with pytest.raises(FileNotFoundError):
+        load_extern_type("/nonexistent/path.py", "SomeType")
+
+
+def test_load_extern_type_nonexistent_type():
+    """Test behavior when type doesn't exist in the file"""
+    with pytest.raises(AttributeError):
+        load_extern_type(TEST_MODULE_PATH, "NonExistentType")
+
+
+def test_load_extern_type_none_path():
+    """Test behavior when file path is None"""
+    result = load_extern_type(None, "SomeType")
+    assert result is None
+
+
+def test_load_extern_type_invalid_module():
+    """Test behavior when module has syntax errors"""
+    # Create a temporary file with syntax errors
+    import tempfile
+
+    with tempfile.NamedTemporaryFile(suffix='.py', mode='w+', delete=False) as temp_file:
+        temp_file.write("This is not valid Python syntax :")
+        temp_path = temp_file.name
+
+    try:
+        with pytest.raises(RuntimeError):
+            load_extern_type(temp_path, "SomeType")
+    finally:
+        # Clean up the temporary file
+        if os.path.exists(temp_path):
+            os.remove(temp_path)

--- a/tests/verl/utils/test_module.py
+++ b/tests/verl/utils/test_module.py
@@ -1,0 +1,16 @@
+# Test module for import_utils.load_extern_type testing
+class TestClass:
+    """A test class to be imported by load_extern_type"""
+
+    def __init__(self, value=None):
+        self.value = value or "default"
+
+    def get_value(self):
+        return self.value
+
+
+TEST_CONSTANT = "test_constant_value"
+
+
+def test_function():
+    return "test_function_result"


### PR DESCRIPTION
This PR adds comprehensive unit tests for the `load_extern_type` function in `verl/utils/import_utils.py`. The tests cover all code paths and edge cases, including:

- Loading different types of objects (classes, functions, constants)
- Handling error cases (nonexistent files, nonexistent types, invalid modules)
- Handling edge cases (None file path)

All tests pass successfully.